### PR TITLE
[Octo-Pro] Divides module/script between installation and configuration

### DIFF
--- a/Octo-Pro/config.sh
+++ b/Octo-Pro/config.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+while true; do
+	read -p "Please select your configuration target? [Controller (c), Worker(w), All (a), or Exit (e)] " cwae
+    case $cwae in
+        [Cc]* ) echo "Configuring Controller Node"; ansible-playbook -i hosts master-playbook.yml --tags configure; exit;;
+        [Ww]* ) echo "Configuring Worker Nodes"; ansible-playbook -i hosts node-playbook.yml --tags configure; exit;;
+        [Aa]* ) echo "Configuring Controller and Worker Nodes"; ansible-playbook -i hosts master-playbook.yml --tags configure; ansible-playbook -i hosts node-playbook.yml --tags configure; exit;;
+        [Ee]* ) exit;;
+        * ) echo "Please select (c), (w), (a) or (v) ?";;
+    esac
+done

--- a/Octo-Pro/master-playbook.yml
+++ b/Octo-Pro/master-playbook.yml
@@ -14,20 +14,24 @@
           - curl
           - gnupg-agent
           - software-properties-common
+      tags: install
 
     - name: Add an apt signing key for Docker
       apt_key:
         url: https://download.docker.com/linux/ubuntu/gpg
         state: present
+      tags: install
 
     - name: Get the latest stable version
       shell: lsb_release -cs
       register: stable_version
+      tags: install
 
     - name: Add apt repository for stable version
       apt_repository:
         repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ stable_version.stdout_lines[0] }} stable
         state: present
+      tags: install
 
     - name: Install docker and its dependecies
       apt:
@@ -41,11 +45,13 @@
           - containerd.io
       notify:
         - docker status
+      tags: install
 
     - name: Add "{{ ansible_user }}" current user to docker group
       user:
         name: "{{ ansible_user}}"
         group: docker
+      tags: install
 
     - name: Remove swapfile from /etc/fstab
       mount:
@@ -56,20 +62,24 @@
       with_items:
           - swap
           - none
+      tags: install
 
     - name: Disable swap
       command: swapoff -a
       when: ansible_swaptotal_mb > 0
+      tags: install
 
     - name: Add an apt signing key for Kubernetes
       apt_key:
         url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
         state: present
+      tags: install
 
     - name: Adding apt repository for Kubernetes
       apt_repository:
         repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
         state: present
+      tags: install
 
     - name: Install Kubernetes binaries
       apt:
@@ -81,47 +91,45 @@
           - kubelet
           - kubeadm
           - kubectl
-    
-    #- name: Get the host part of the IP 
-      #shell: host {{ ansible_fqdn }} | awk '{print $4}' 
-      #register: node_ip
-    #  setup:
-    #    node_ip: "{{ ansible_eth1.ipv4.address }}"      
+      tags: install
 
     - name: Creates Kubelet directory
       file:
         path: /etc/default/kubelet
-        state: touch 
+        state: touch
+      tags: install
 
     - name: Configure node ip
       lineinfile:
         name: /etc/default/kubelet
         line: KUBELET_EXTRA_ARGS=--node-ip={{ ansible_eth1.ipv4.address }}
+      tags: install
 
     - name: Restart kubelet
       service:
         name: kubelet
         state: restarted
+      tags: install
 
-#    - name: Reset Cluster
-#      command: kubeadm reset -f
-
-#    - name: Remove previous Cluster config
-#      file:
-#        path: /home/{{ ansible_user }}/.kube 
-#        state: absent
+    - name: Reset Kubernetes component
+      shell: "kubeadm reset --force"
+      ignore_errors: True
+      tags: ['install','configure']
 
     - name: Initialize the Kubernetes cluster using kubeadm
       command: kubeadm init --apiserver-advertise-address {{ ansible_eth1.ipv4.address }} --node-name k8s-master --pod-network-cidr=10.244.0.0/16 --ignore-preflight-errors=All
+      tags: ['install','configure']
 
     - name: Create kubeconfig directory for running user
       file:
         path: /home/{{ ansible_user }}/.kube
         state: directory
         mode: '0755'
+      tags: ['install','configure']
 
     - name: Copy kubeconfig for running user
       command: cp -i /etc/kubernetes/admin.conf /home/{{ ansible_user }}/.kube/config
+      tags: ['install','configure']
   
     - name: Change ownership kubeconfig for running user
       file:
@@ -129,20 +137,24 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0644'
+      tags: ['install','configure']
       
     - name: Install flannel pod network
       become: false
       command: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+      tags: ['install','configure']
 
     - name: Generate join command
       become: false
       command: kubeadm token create --print-join-command
       register: join_command
       ignore_errors: True
+      tags: ['install','configure']
 
     - name: Copy join command to local file
       become: false
       local_action: copy content="{{ join_command.stdout_lines[0] }}" dest="./join-command"
+      tags: ['install','configure']
 
   handlers:
     - name: docker status

--- a/Octo-Pro/master-playbook.yml
+++ b/Octo-Pro/master-playbook.yml
@@ -128,7 +128,7 @@
       tags: ['install','configure']
 
     - name: Copy kubeconfig for running user
-      command: cp -i /etc/kubernetes/admin.conf /home/{{ ansible_user }}/.kube/config
+      command: cp -fr /etc/kubernetes/admin.conf /home/{{ ansible_user }}/.kube/config
       tags: ['install','configure']
   
     - name: Change ownership kubeconfig for running user

--- a/Octo-Pro/node-playbook.yml
+++ b/Octo-Pro/node-playbook.yml
@@ -14,20 +14,24 @@
           - curl
           - gnupg-agent
           - software-properties-common
+      tags: install
 
     - name: Add an apt signing key for Docker
       apt_key:
         url: https://download.docker.com/linux/ubuntu/gpg
         state: present
+      tags: install
 
     - name: Get the latest stable version
       shell: lsb_release -cs
       register: stable_version
+      tags: install
 
     - name: Add apt repository for stable version
       apt_repository:
         repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ stable_version.stdout_lines[0] }} stable
         state: present
+      tags: install
 
     - name: Install docker and its dependecies
       apt:
@@ -42,11 +46,13 @@
           - containerd.io
       notify:
         - docker status
+      tags: install
 
     - name: Add current "{{ ansible_user }}" to docker group
       user:
         name: "{{ ansible_user }}"
         group: docker
+      tags: install
 
     - name: Remove swapfile from /etc/fstab
       mount:
@@ -57,20 +63,24 @@
       with_items:
           - swap
           - none
+      tags: install
 
     - name: Disable swap
       command: swapoff -a
       when: ansible_swaptotal_mb > 0
+      tags: install
 
     - name: Add an apt signing key for Kubernetes
       apt_key:
         url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
         state: present
+      tags: install
 
     - name: Adding apt repository for Kubernetes
       apt_repository:
         repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
         state: present
+      tags: install
 
     - name: Install Kubernetes binaries
       apt:
@@ -82,24 +92,30 @@
           - kubelet
           - kubeadm
           - kubectl
+      tags: install
 
     - name: Restart kubelet
       service:
         name: kubelet
         state: restarted
+      tags: install
 
-#    - name: Copy the join command to server location
-#      copy: src=/vagrant/join-command dest=/tmp/join-command.sh mode=077
+    - name: Reset Kubernetes component
+      shell: "kubeadm reset --force"
+      ignore_errors: True
+      tags: ['install','configure']
 
     - name: Change ownership of join cluster file
       file:
-        path: /vagrant/join-command
+        path: join-command
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0755'
+      tags: ['install','configure']
 
     - name: Join the node to cluster
-      command: sh /vagrant/join-command
+      command: sh join-command
+      tags: ['install','configure']
 
   handlers:
     - name: docker status

--- a/Octo-Pro/node-playbook.yml
+++ b/Octo-Pro/node-playbook.yml
@@ -105,16 +105,8 @@
       ignore_errors: True
       tags: ['install','configure']
 
-    - name: Change ownership of join cluster file
-      file:
-        path: join-command
-        owner: "{{ ansible_user }}"
-        group: "{{ ansible_user }}"
-        mode: '0755'
-      tags: ['install','configure']
-
     - name: Join the node to cluster
-      command: sh join-command
+      script: ./join-command
       tags: ['install','configure']
 
   handlers:

--- a/Octo-Pro/setup.sh
+++ b/Octo-Pro/setup.sh
@@ -1,11 +1,11 @@
-#/bin/sh
+#!/bin/sh
 
 sudo apt-get update
 sudo apt-get install ansible -y
 
 while true; do
-	read -p "Please select your installation target? [Controller (c), Worker(w), All (a), Volume(v), or Exit (e)] " cwae
-    case $cwae in
+	read -p "Please select your installation target? [Controller (c), Worker(w), All (a), Volume(v), or Exit (e)] " cwave
+    case $cwave in
         [Cc]* ) echo "Installing Controller Node"; ansible-playbook -i hosts master-playbook.yml; exit;;
         [Ww]* ) echo "Installing Worker Nodes"; ansible-playbook -i hosts node-playbook.yml; exit;;
         [Aa]* ) echo "Installing Controller and Worker Nodes"; ansible-playbook -i hosts master-playbook.yml; ansible-playbook -i hosts node-playbook.yml; exit;;


### PR DESCRIPTION
This PR tried to tag the Ansible script with "installation" and "configuration" in order to avoid repetition tasks. It is mentioned in this issue #23.