### PR TITLE
[Octo-Bot/file-transfer-bot] bug fix (resolve issue #50)

### DIFF
--- a/Octo-Bot/file-transfer-bot/bot/ftp_starter.py
+++ b/Octo-Bot/file-transfer-bot/bot/ftp_starter.py
@@ -23,9 +23,9 @@ def main():
                         help="download function(upload/download)",
                             default=['download'])
     parser.add_argument("-uf", metavar = 'uploaded_file',
-                        help="file to be uploaded",  required=False,
+                        help="file to be uploaded",  required=False, nargs='+',
                           default=['/large_file'])
-    parser.add_argument("-df", metavar = 'downloaded_file',required=False,
+    parser.add_argument("-df", metavar = 'downloaded_file',required=False, nargs='+',
                         help="file to be downloaded",default=['large_file'])
 
     args = parser.parse_args()


### PR DESCRIPTION
now ftp-starter.py in file-transfer-bot parses the whole name of the downloaded/uploaded file

resolving issue #50 